### PR TITLE
Reskin txt to com

### DIFF
--- a/plugins/txt/help/en/txt.md
+++ b/plugins/txt/help/en/txt.md
@@ -1,30 +1,33 @@
 ---
 toc: Playing the Game
-summary: How to send texts.
+summary: How to send commlink/text messages.
 aliases:
+- com
+- commlink
+- cl
 - text
 - Texting
 - texts
 ---
 
-## Texting from the Web-Portal
-There is a "Send Txt" button on any active scene in the web-portal. Texting into a scene will send a message in-game, if the character is connected. Otherwise, it will just send a text into the scene.
+## Messaging from the Web-Portal
+There is a "Send Msg" button on any active scene in the web-portal. Messaging into a scene will send a message in-game, if the character is connected. Otherwise, it will just send a message into the scene.
 
-`<name>=<message>` - Send a message to a person from the webportal. If the recipient isn't already a participant in the scene, this will add them.
+`<name>=<message>` - Send a message to a person from the web-portal. If the recipient isn't already a participant in the scene, this will add them.
 
-> Keep in mind that someone who's not logged in won't know they've been texted in a scene unless they check! Be courteous!
+> Keep in mind that someone who's not logged in won't know they've been messaged in a scene unless they check! Be courteous!
 
 ## Commands
-`txt <name> [<name> <name>]=<message>` - Send a message to name(s).
-`txt <name> [<name> <name>]/<scene #>=<message>` - Send a text to name + log it in a scene. If the recipient isn't already a participant in the scene, this will add them.
+`com <name> [<name> <name>]=<message>` - Send a message to name(s).
+`com <name> [<name> <name>]/<scene #>=<message>` - Send a message to name + log it in a scene. If the recipient isn't already a participant in the scene, this will add them.
 
-`txt [=]<message>` - Send a message to your last text target + last scene.
+`com [=]<message>` - Send a message to your last target + last scene.
 
-`txt/reply` - See who last texted you.
-`txt/reply <message>` - Reply to the last text (including all recipients + scene, if there is one)
+`com/reply` - See who last messaged you.
+`com/reply <message>` - Reply to the last message (including all recipients + scene, if there is one)
 
-`txt/newscene <name> [<name> <name>]=<message>` - Starts a new scene + sends a message to those names + the scene.
+`com/newscene <name> [<name> <name>]=<message>` - Starts a new scene + sends a message to those names + the scene.
 
-`txt/color <color>` - Color the (TXT to <name>) prefix. Use ansi color format for this, ex: \%xh\%xr for red highlight, \%xh\%xg for green highlight.
+`com/color <color>` - Color the (MSG to <name>) prefix. Use ansi color format for this, ex: \%xh\%xr for red highlight, \%xh\%xg for green highlight.
 
-> If you do not wish to receive txts (in general, or from a specific person), the `page/ignore <name>=<on/off>` and `page/dnd <on/off>` commands will block txts as well.
+> If you do not wish to receive coms (in general, or from a specific person), the `page/ignore <name>=<on/off>` and `page/dnd <on/off>` commands will block coms as well.

--- a/plugins/txt/locales/locale_en.yml
+++ b/plugins/txt/locales/locale_en.yml
@@ -3,33 +3,33 @@ en:
   txt:
 
       txt_target_missing: "Beep boop: To whom shall I send this message?"
-      cant_txt_ignored: "You can't txt %{names} because you're on their ignore list."
-      recipient_do_not_disturb: "%{name} is set 'do not disturb' right now.  Please try your text again later."
+      cant_txt_ignored: "You can't com %{names} because you're on their ignore list."
+      recipient_do_not_disturb: "%{name} is set 'do not disturb' right now.  Please try your com again later."
       target_offline_no_scene: "%{name} is not connected and you did not specify a scene."
 
       txt_to_sender: "%{txt} %{sender}%xn: %{message}%xn"
       txt_to_recipient: "%{txt} %{sender}%xn: %{message}%xn"
       txt_to_recipient_with_scene: "%{txt} %xh%{sender}%xn: %{message} %xx%xh(Scene %{scene_id})%xn"
 
-      recipient_added_to_scene: "That text has added %{name} to the scene participants list."
+      recipient_added_to_scene: "That com has added %{name} to the scene participants list."
       txt_to_scene_with_recipient: "%{txt} %xh%xw %{sender}%xn: %{message}%xn"
       txt_to_scene_no_recipient: "%{txt} %xh%xw %{sender}%xn: %{message}%xn"
       no_such_character: "No character found by that name."
 
-      no_one_to_reply_to: "Looks like no one's txt'd you recently. Sorry."
-      reply_scene: "Last txt came from: %{names}; Scene: %{scene}"
-      reply: "Last txt came from: %{names}"
+      no_one_to_reply_to: "Looks like no one's com'ed you recently. Sorry."
+      reply_scene: "Last com came from: %{names}; Scene: %{scene}"
+      reply: "Last com came from: %{names}"
 
       recipient_indicator: "%{recipients}"
 
-      txt_indicator: "%{color}%{start_marker}TXT to %{recipients}%{color}%{end_marker}%xn"
+      txt_indicator: "%{color}%{start_marker}COM to %{recipients}%{color}%{end_marker}%xn"
 
-      color_set: "Txts will now appear with this marker: %{option}%%%xn"
+      color_set: "Coms will now appear with this marker: %{option}%%%xn"
 
-      scene_not_running: "That scene isn't running.  You'll need to restart it if you want to txt into it."
-      scene_no_access: "You do not have access to txt into that scene. Ask the participants to add you. (Try: scene/addchar #=character )"
+      scene_not_running: "That scene isn't running.  You'll need to restart it if you want to com into it."
+      scene_no_access: "You do not have access to com into that scene. Ask the participants to add you. (Try: scene/addchar #=character )"
       scene_not_found: "No scene found by that number."
 
       incorrect_format: "That's not the correct format. Please use `name(s)=message`"
 
-      txt_new_scene_target_missing: "Please specify a target and message. Ex: txt/newscene Name=Message"
+      txt_new_scene_target_missing: "Please specify a target and message. Ex: com/newscene <name>=<message>"


### PR DESCRIPTION
We want to use the txt plugin as a commlink, so this just changes all mentions of texts, txt, etc, into neutral terms like message and more opinionated terms like com (when necessary).